### PR TITLE
use --device option instead of -v for Skype

### DIFF
--- a/skype/Dockerfile
+++ b/skype/Dockerfile
@@ -1,7 +1,7 @@
 # Run skype in a container
 #
 # docker run -v /tmp/.X11-unix:/tmp/.X11-unix \
-#     -v /dev/snd:/dev/snd \
+#     --device=/dev/snd:/dev/snd \
 #     -e DISPLAY=unix$DISPLAY \
 #     jess/skype
 #


### PR DESCRIPTION
Since Docker 1.2, use of --device is recommended for devices.