### PR TITLE
Add Ex: Reducing the size of the image using Alpine

### DIFF
--- a/alpine-t/Dockerfile
+++ b/alpine-t/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:latest
+
+MAINTAINER Daniel Romero <infoslack@gmail.com>
+
+RUN apk update 
+RUN apk add ca-certificates ruby-dev build-base && rm -rf /var/cache/apk/*
+RUN gem install t
+
+ENTRYPOINT [ "t" ]

--- a/alpine-t/README.md
+++ b/alpine-t/README.md
@@ -1,0 +1,21 @@
+alpine-t 
+=========
+Docker image based on Alpine Linux ;)
+
+### What is Alpine ?
+
+Alpine Linux is a Linux distribution built around musl libc and BusyBox.
+The image is only 5 MB in size and has access to a package repository 
+that is much more complete than other BusyBox based images. 
+More: [https://registry.hub.docker.com/_/alpine/](https://registry.hub.docker.com/_/alpine/)
+
+### Why ?
+
+Image based `ruby:latest` vs `alpine:latest`:
+
+```
+$ docker images
+REPOSITORY                    TAG                 VIRTUAL SIZE
+infoslack/alpine-t            latest              161.4 MB
+infoslack/t                   latest              781.5 MB
+```


### PR DESCRIPTION
This is an example based on Alpine Linux: https://registry.hub.docker.com/_/alpine/
Only to demonstrate an awesome image size reduction:

```
$ docker images
REPOSITORY                    TAG                 VIRTUAL SIZE
infoslack/alpine-t            latest              161.4 MB
infoslack/t                   latest              781.5 MB
```