### PR TITLE
magic function to auto-exec containers

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -1,0 +1,23 @@
+command_not_found_handle () {
+    # Check if there is a container image with that name
+    if ! docker inspect --format '{{ .Author }}' "$1" >&/dev/null
+    then
+	echo "$0: $1: command not found"
+	return
+    fi
+    # Check that it's really the name of the image, not a prefix
+    if docker inspect --format '{{ .Id }}' "$1" | grep -q "^$1"
+    then
+	echo "$0: $1: command not found"
+	return
+    fi
+    docker run -ti -u $(whoami) -w "$HOME" \
+	$(env | cut -d= -f1 | awk '{print "-e", $1}') \
+	-v /dev/snd:/dev/snd \
+	-v /etc/passwd:/etc/passwd:ro \
+	-v /etc/group:/etc/group:ro \
+	-v /etc/localtime:/etc/localtime:ro \
+	-v /home:/home \
+	-v /tmp/.X11-unix:/tmp/.X11-unix \
+	"$@"
+}


### PR DESCRIPTION
This Sysadmin Automatically Run Containers From The Shell With This Weird Trick! Distro Packagers Hate Them!

OK, so if you put this in your bashrc, now you try to run `foo` from your shell but there is no `foo` binary/builtin/function/alias, then it will look for a container image called `foo` and if it is found it will run it. If you like, I can write a README or something (or put that outside of your repo, but I thought it was like the perfect place?)