### PR TITLE
Add an alias for combined usage of figlet and lolcat in nerdy image

### DIFF
--- a/nerdy/Dockerfile
+++ b/nerdy/Dockerfile
@@ -17,5 +17,6 @@ WORKDIR $HOME
 COPY ./lolcat /usr/bin/lolcat
 
 RUN echo 'image_me() { convert $1 jpg:- | jp2a ${*:2} -; }' >> $HOME/.bashrc
+RUN echo 'figlet_lolcat() { figlet $1 | lolcat; }' >> $HOME/.bashrc
 
 ENTRYPOINT [ "bash" ]


### PR DESCRIPTION
This will make it possible to use the combination of figlet and lolcat without the need to entry the container.

```
$ docker run --rm -it denderello/nerdy -lc "figlet_lolcat 'hello jessie'"
```

![screen shot 2015-04-17 at 20 15 02](https://cloud.githubusercontent.com/assets/15523/7208108/81abdb92-e53e-11e4-8e13-aeac08c13634.png)