### PR TITLE
updating tor-browser to 4.5.1 to keep up with sec updates

### DIFF
--- a/tor-browser/Dockerfile
+++ b/tor-browser/Dockerfile
@@ -25,7 +25,7 @@ RUN useradd --create-home --home-dir $HOME user \
 
 ENV LANG C.UTF-8
 
-ENV TOR_VERSION 4.5
+ENV TOR_VERSION 4.5.1
 
 RUN curl -sSL "https://www.torproject.org/dist/torbrowser/${TOR_VERSION}/tor-browser-linux64-${TOR_VERSION}_en-US.tar.xz" | tar -v -C /usr/local/bin -xJ --strip-components 1 
 


### PR DESCRIPTION
Really like your readily available images (and the blog posts that documented how to use them!), however I just noticed the tor-browser one was missing the latest point release and it always makes one uneasy to see Tor Browser whining :)

https://blog.torproject.org/blog/tor-browser-451-released
