### PR TITLE
use node base image and improve build time/space

### DIFF
--- a/atom/Dockerfile
+++ b/atom/Dockerfile
@@ -20,32 +20,26 @@
 #
 
 # Base docker image
-FROM debian:jessie
+FROM node
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
 # Install dependencies
-RUN apt-get update && apt-get install -y \
-	build-essential \
-	ca-certificates \
-	curl \
-	git \
-	libasound2 \
-	libgconf-2-4 \
-	libgnome-keyring-dev \
-	libgtk2.0-0 \
-	libnss3 \
-	libxtst6 \
-	--no-install-recommends
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    libasound2 \
+    libgconf-2-4 \
+    libgnome-keyring-dev \
+    libgnome-keyring-dev \
+    libgtk2.0-0 \
+    libnss3 \
+    libxtst6 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# install node
-RUN curl -sL https://deb.nodesource.com/setup | bash -
-RUN apt-get install -y nodejs
-
-# clone atom
-RUN git clone https://github.com/atom/atom /src
 WORKDIR /src
-RUN git fetch && git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
-RUN script/build && script/grunt install
+
+RUN LATEST_TAG=`git ls-remote --tags https://github.com/atom/atom | sort -t '/' -k3 --version-sort | tail -n1 | cut -d'/' -f3` && \
+    git clone -b $LATEST_TAG https://github.com/atom/atom --depth 1 /src && \
+    script/build && script/grunt install && \
+    rm -fr /src
 
 # Autorun atom
 CMD /usr/local/bin/atom --foreground --log-file /var/log/atom.log && tail -f /var/log/atom.log


### PR DESCRIPTION
Improvements:
- Use node base image
- Flatten images to decrease layers' size
- Do a shallow clone to speedup build time

---

Here is some comparison between the docker file without and with my changes.
The shallow clone change will be appreciated for those who has a slow connection.
Note: parts of the output has my name on it since my local docker file from which I get the details has me as a maintainer, the other stuff is the same as the pull request contents.

```
# Build times
docker build --no-cache=true -t test/atom .  0.04s user 0.01s system 0% cpu 35:55.18 total
docker build --no-cache=true -t test/jfrazelle-atom .  0.06s user 0.05s system 0% cpu 50:04.54 total

# Images size
➜ docker images | grep atom
test/atom                                      latest              58ab582820a2        About an hour ago   1.47 GB
test/jfrazelle-atom                            latest              00308fb3f921        About an hour ago   1.845 GB

# Intermediate layers size

➜ docker history test/atom
IMAGE               CREATED             CREATED BY                                      SIZE
58ab582820a2        About an hour ago   /bin/sh -c #(nop) CMD ["/bin/sh" "-c" "/usr/l   0 B
56e021ca105a        About an hour ago   /bin/sh -c LATEST_TAG=`git ls-remote --tags h   703.6 MB
96c971337755        About an hour ago   /bin/sh -c #(nop) WORKDIR /src                  0 B
1aa7459a82f1        About an hour ago   /bin/sh -c apt-get update && DEBIAN_FRONTEND=   55.75 MB
c14c537295d0        About an hour ago   /bin/sh -c #(nop) MAINTAINER Ivan Alejandro <   0 B
3575f1347ce7        6 days ago          /bin/sh -c #(nop) CMD ["node"]                  0 B
a52a290821b3        6 days ago          /bin/sh -c curl -SLO "http://nodejs.org/dist/   33.51 MB
9332645b03a3        6 days ago          /bin/sh -c #(nop) ENV NPM_VERSION=2.11.0        0 B
d1744e6e9471        12 days ago         /bin/sh -c #(nop) ENV NODE_VERSION=0.12.4       0 B
7711db4bb553        13 days ago         /bin/sh -c gpg --keyserver pool.sks-keyserver   22.25 kB
c9e3effdd23a        2 weeks ago         /bin/sh -c apt-get update && apt-get install    385.7 MB
a2703ed272d7        2 weeks ago         /bin/sh -c apt-get update && apt-get install    122.3 MB
7a3871ba15f8        2 weeks ago         /bin/sh -c apt-get update && apt-get install    44.33 MB
df2a0347c9d0        2 weeks ago         /bin/sh -c #(nop) CMD ["/bin/bash"]             0 B
39bb80489af7        2 weeks ago         /bin/sh -c #(nop) ADD file:5de08c81c24812789a   125.1 MB

➜ docker history test/jfrazelle-atom
IMAGE               CREATED             CREATED BY                                      SIZE
00308fb3f921        About an hour ago   /bin/sh -c #(nop) CMD ["/bin/sh" "-c" "/usr/l   0 B
4fdc6648b7e0        About an hour ago   /bin/sh -c script/build && script/grunt insta   1.068 GB
9c6587561388        2 hours ago         /bin/sh -c git fetch && git checkout $(git de   554.9 kB
f09302daac4d        2 hours ago         /bin/sh -c #(nop) WORKDIR /src                  0 B
6c73ef5b6186        2 hours ago         /bin/sh -c git clone https://github.com/atom/   285.2 MB
11c4eabcf428        2 hours ago         /bin/sh -c apt-get install -y nodejs            19.92 MB
cae2aaf18ca9        2 hours ago         /bin/sh -c curl -sL https://deb.nodesource.co   1.045 MB
75bf552dfe52        2 hours ago         /bin/sh -c apt-get update && apt-get install    345.6 MB
ea8c28bf4c68        2 hours ago         /bin/sh -c #(nop) MAINTAINER Jessica Frazelle   0 B
61e9c91c4f08        6 weeks ago         /bin/sh -c #(nop) CMD ["/bin/bash"]             0 B
9faf01c9b0ef        6 weeks ago         /bin/sh -c #(nop) ADD file:a50d79b5ca65ccabb5   125.1 MB

# Clone size
➜ du -sh *
279M    atom.full-repo
16M     atom.shallow-clone
```

I hope this helps.
P.s. thanks for the article! (https://blog.jessfraz.com/post/docker-containers-on-the-desktop/)