### PR TITLE
Update stress to use ENTRYPOINT instead of CMD

### DIFF
--- a/stress/Dockerfile
+++ b/stress/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
-CMD [ "stress" ]
+ENTRYPOINT [ "stress" ]


### PR DESCRIPTION
This is to avoid the ugly: docker run jess/stress stress -c 4 ... and instead use what's in the example usage: https://registry.hub.docker.com/u/jess/stress/