### PR TITLE
Do not error on dpkg missing dependencies.

### DIFF
--- a/skype/Dockerfile
+++ b/skype/Dockerfile
@@ -23,7 +23,7 @@ RUN dpkg --add-architecture i386 && \
 
 # Install Skype
 RUN curl http://download.skype.com/linux/skype-debian_4.3.0.37-1_i386.deb > /usr/src/skype.deb && \ 
-	dpkg -i /usr/src/skype.deb && \
+	dpkg --force-depends -i /usr/src/skype.deb && \
 	apt-get install -fy \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
WIthout this option to dpkg I get the following error when running docker build.

Unpacking skype (4.3.0.37-1) ...
dpkg: dependency problems prevent configuration of skype:
 skype depends on libc6 (>= 2.3.6-6~).
 skype depends on libc6 (>= 2.7).
 skype depends on libgcc1 (>= 1:4.1.1).
 skype depends on libqt4-dbus (>= 4:4.5.3).
 skype depends on libqt4-network (>= 4:4.8.0).
 skype depends on libqt4-xml (>= 4:4.5.3).
 skype depends on libqtcore4 (>= 4:4.7.0~beta1).
 skype depends on libqtgui4 (>= 4:4.8.0).
 skype depends on libqtwebkit4 (>= 2.1.0~2011week13).
 skype depends on libstdc++6 (>= 4.2.1).
 skype depends on libx11-6.
 skype depends on libxext6.
 skype depends on libxss1.
 skype depends on libxv1.
 skype depends on libssl1.0.0.
 skype depends on libpulse0.
 skype depends on libasound2-plugins.

dpkg: error processing package skype (--install):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 skype
INFO[0009] The command [/bin/sh -c curl http://download.skype.com/linux/skype-debian_4.3.0.37-1_i386.deb > /usr/src/skype.deb &&        dpkg -i /usr/src/skype.deb &&     apt-get install -fy     && rm -rf /var/lib/apt/lists/*] returned a non-zero code: 1