### PR TITLE
Ensure version 42.0.2311.152 is installed.

### DIFF
--- a/chrome/stable/Dockerfile
+++ b/chrome/stable/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Jessica Frazelle <jess@docker.com>
 
 COPY google-talkplugin_current_amd64.deb /src/google-talkplugin_current_amd64.deb
 
-ADD  https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb /src/google-chrome-stable_current_amd64.deb
+ADD  http://mirror.pcbeta.com/google/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_42.0.2311.152-1_amd64.deb /src/google-chrome-stable_current_amd64.deb
 
 # Install Chromium
 RUN mkdir -p /usr/share/icons/hicolor && \


### PR DESCRIPTION
Jess, unsure if you are witnessing the same error or not with running Chrome in Docker, however I am receiving Google Chrome tab crashes when accessing certain URLS (http://www.thebiggame.org is a good test, noticed elsewhere also) with the new versions.

I cant be sure what it is exactly that causes the crash, however I have identified that version 42.0.2311.135-1 is able to render the sites, however the next release (43.0.2357.65-1) does not.

Annoyingly Google are not hosting their older versions of google-chrome-stable in their Debian repository, however I was able to find a (slightly questionable) mirror. That being said I have checked the sha256 hash and gpg signing key on the deb package and it looks legitimate.

Note: This is probably more of an FYI than an authentic pull request. It would be interesting to hear of your experiences.