### PR TITLE
Add mising compiler for `jess/rust`

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:jessie
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
 RUN apt-get update && apt-get install -y \
+	build-essential \
 	ca-certificates \
 	curl \
 	--no-install-recommends \


### PR DESCRIPTION
A compiler is needed to make rust libraries work with FFI.  Sadly you can't just
included gcc, you need a *ton* of headeres, thus: `build-essential`
