### PR TITLE
Updated with correct binary name.

### DIFF
--- a/imagemagick/Dockerfile
+++ b/imagemagick/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
-CMD [ "imagemagick" ]
+CMD [ "convert" ]


### PR DESCRIPTION
"imagemagick" is not on path. The binary name is "convert."