### PR TITLE
Add more devices, but only if they really exist

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -13,13 +13,31 @@ command_not_found_handle () {
 		return
 	fi
 
+	# Add a bunch of (optional) devices
+	# (Don't add them unconditionally: if they don't exist, it
+	# would prevent the container from starting)
+	DEVICES=
+	for DEV in /dev/kvm /dev/ttyUSB* /dev/dri/* /dev/snd/*; do
+		if [ -b "$DEV" -o -c "$DEV" ]; then
+			DEVICES="$DEVICES --device $DEV:$DEV"
+		fi
+	done
+
+	# And a few (optional) files
+	# (Here again, they don't always exist everywhere)
+	VOLUMES=
+	for VOL in /tmp/.X11-unix /run/user; do
+		if [ -e "$VOL" ]; then
+			VOLUMES="$VOLUMES --volume $VOL:$VOL"
+		fi
+	done
+
 	docker run -ti -u $(whoami) -w "$HOME" \
 		$(env | cut -d= -f1 | awk '{print "-e", $1}') \
-		-v /dev/snd:/dev/snd \
+		$DEVICES $VOLUMES \
 		-v /etc/passwd:/etc/passwd:ro \
 		-v /etc/group:/etc/group:ro \
 		-v /etc/localtime:/etc/localtime:ro \
 		-v /home:/home \
-		-v /tmp/.X11-unix:/tmp/.X11-unix \
 		"$@"
 }


### PR DESCRIPTION
This will bring `/dev/kvm`, `/dev/ttyUSB*`, and a bunch of other niceties in the container, but *conditionally*. (Because if we try to specify non-existent devices, Docker will boo at us.)