### PR TITLE
Adds $DOCKERFILES_RUN_FLAGS

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -38,7 +38,7 @@ command_not_found_handle () {
 
 	docker run $DASHT -i -u $(whoami) -w "$HOME" \
 		$(env | cut -d= -f1 | awk '{print "-e", $1}') \
-		$DEVICES $VOLUMES \
+		$DOCKERFILES_RUN_FLAGS $DEVICES $VOLUMES \
 		-v /etc/passwd:/etc/passwd:ro \
 		-v /etc/group:/etc/group:ro \
 		-v /etc/localtime:/etc/localtime:ro \


### PR DESCRIPTION
Ridiculous one-line change to allow leazily* to add flags when running containers through the bash fallthru hook.

Adds $DOCKERFILES_RUN_FLAGS when running containers through command_not_found_handle

*I just made up that word, it's a portemanteau between lazy and easy.