### PR TITLE
Add less to the awscli image

### DIFF
--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Jessica Frazelle <jess@docker.com>
 RUN apk update && apk add \
 	ca-certificates \
 	groff \
+	less \
 	python \
 	py-pip \
 	&& rm -rf /var/cache/apk/* \


### PR DESCRIPTION
The awscli image is based on `alpine`, and on `alpine`, `less` is provided by `busybox`.

As a result, trying to get help with the AWS CLI yields a message like the following:
```
aws ecs help
less: unrecognized option: R
BusyBox v1.23.2 (2015-04-24 15:46:01 GMT) multi-call binary.

Usage: less [-EIMmNh~] [FILE]...
...
```

By adding `less` to the alpine packages installed, we get the expected behavior and when we're dazed and confused by the AWS CLI we can actually RTFM instead of rage-tweeting and engaging in other counter-productive activities.

♥📦🐋,