### PR TITLE
add fonts-liberation to apt install package list

### DIFF
--- a/chrome/stable/Dockerfile
+++ b/chrome/stable/Dockerfile
@@ -20,12 +20,13 @@ MAINTAINER Jessica Frazelle <jess@docker.com>
 
 ADD https://dl.google.com/linux/direct/google-talkplugin_current_amd64.deb /src/google-talkplugin_current_amd64.deb
 
-ADD  https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb /src/google-chrome-stable_current_amd64.deb
+ADD https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb /src/google-chrome-stable_current_amd64.deb
 
 # Install Chromium
 RUN mkdir -p /usr/share/icons/hicolor && \
 	apt-get update && apt-get install -y \
 	ca-certificates \
+	fonts-liberation \
 	gconf-service \
 	hicolor-icon-theme \
 	libappindicator1 \


### PR DESCRIPTION
google-chrome-stable is failing to install without the fonts-liberation package.

Putting it in the package list fixed the issue for me.