### PR TITLE
Spotify fixes

### DIFF
--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -4,17 +4,19 @@
 FROM ubuntu:14.04
 MAINTAINER Jessie Frazelle <jess@linux.com>
 
-RUN apt-get update && apt-get install -y \
-	libpangoxft-1.0-0 \
-	software-properties-common \
-	pulseaudio \
-	--no-install-recommends && \
-	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 94558F59 && \
-	echo "deb http://repository.spotify.com stable non-free" >> /etc/apt/sources.list.d/spotify.list && \
+RUN \
+	apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys BBEBDCB318AD50EC6865090613B00F1FD2C19886 && \
+	echo "deb http://repository.spotify.com testing non-free" >> /etc/apt/sources.list.d/spotify.list && \
 	apt-get update && \
-	apt-get install --force-yes -y \
-	spotify-client \
-	&& rm -rf /var/lib/apt/lists/*
+	apt-get install -y --no-install-recommends \
+	  libpangoxft-1.0-0 \
+	  software-properties-common \
+	  xdg-utils \
+	  libxss1 \
+	  pulseaudio \
+	  spotify-client \
+	  && \
+	rm -rf /var/lib/apt/lists/*
 
 ENV HOME /home/spotify
 RUN useradd --create-home --home-dir $HOME spotify \

--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -1,18 +1,6 @@
 # Run spotify in a container
 #
 # Note: You might have to uncheck "Enable hardware acceleration" in the preferences.
-#
-# docker run -d \
-#	-v /etc/localtime:/etc/localtime:ro \
-#	-v /tmp/.X11-unix:/tmp/.X11-unix:ro \
-#	-e DISPLAY=unix$DISPLAY \
-#	-v $HOME/.spotify/config:/home/spotify/.config/spotify \
-#	-v $HOME/.spotify/cache:/home/spotify/.cache/spotify \
-#	-v /run/user/$UID/pulse:/run/pulse:ro \
-#	-e PULSE_SERVER=/run/pulse/native \
-#	--name spotify \
-#	jess/spotify
-#
 FROM ubuntu:14.04
 MAINTAINER Jessie Frazelle <jess@linux.com>
 
@@ -38,6 +26,9 @@ USER spotify
 
 # make search bar text better
 RUN echo "QLineEdit { color: #000 }" > /home/spotify/spotify-override.css
+
+# make dbus socket a real file so we can get at it through the filesystem
+ADD session-local.conf /etc/dbus-1/session-local.conf
 
 ENTRYPOINT [ "spotify" ]
 CMD [ "-stylesheet=/home/spotify/spotify-override.css" ]

--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -1,12 +1,15 @@
 # Run spotify in a container
 #
+# Note: You might have to uncheck "Enable hardware acceleration" in the preferences.
+#
 # docker run -d \
 #	-v /etc/localtime:/etc/localtime:ro \
-#	-v /tmp/.X11-unix:/tmp/.X11-unix \
+#	-v /tmp/.X11-unix:/tmp/.X11-unix:ro \
 #	-e DISPLAY=unix$DISPLAY \
-#	--device /dev/snd:/dev/snd \
 #	-v $HOME/.spotify/config:/home/spotify/.config/spotify \
-#	-v $HOME/.spotify/cache:/home/spotify/spotify \
+#	-v $HOME/.spotify/cache:/home/spotify/.cache/spotify \
+#	-v /run/user/$UID/pulse:/run/pulse:ro \
+#	-e PULSE_SERVER=/run/pulse/native \
 #	--name spotify \
 #	jess/spotify
 #
@@ -15,8 +18,8 @@ MAINTAINER Jessie Frazelle <jess@linux.com>
 
 RUN apt-get update && apt-get install -y \
 	libpangoxft-1.0-0 \
-	alsa-utils \
 	software-properties-common \
+	pulseaudio \
 	--no-install-recommends && \
 	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 94558F59 && \
 	echo "deb http://repository.spotify.com stable non-free" >> /etc/apt/sources.list.d/spotify.list && \
@@ -36,5 +39,5 @@ USER spotify
 # make search bar text better
 RUN echo "QLineEdit { color: #000 }" > /home/spotify/spotify-override.css
 
-ENTRYPOINT	[ "spotify" ]
+ENTRYPOINT [ "spotify" ]
 CMD [ "-stylesheet=/home/spotify/spotify-override.css" ]

--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -29,8 +29,7 @@ USER spotify
 # make search bar text better
 RUN echo "QLineEdit { color: #000 }" > /home/spotify/spotify-override.css
 
-# make dbus socket a real file so we can get at it through the filesystem
-ADD session-local.conf /etc/dbus-1/session-local.conf
+# add wrapper script
+ADD startup /usr/bin/startup
 
-ENTRYPOINT [ "spotify" ]
-CMD [ "-stylesheet=/home/spotify/spotify-override.css" ]
+ENTRYPOINT [ "startup" ]

--- a/spotify/run
+++ b/spotify/run
@@ -1,0 +1,16 @@
+#!/bin/bash
+mkdir -p $HOME/.spotify/{config,cache,dbus}
+chmod 700 $HOME/.spotify
+chmod 777 $HOME/.spotify/*
+exec docker run \
+      --rm \
+      -v /etc/localtime:/etc/localtime:ro \
+      -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
+      -e DISPLAY=unix$DISPLAY \
+      -v $HOME/.spotify/config:/home/spotify/.config/spotify \
+      -v $HOME/.spotify/cache:/home/spotify/.cache/spotify \
+      -v $HOME/.spotify/dbus:/tmp/dbus \
+      -v /run/user/$UID/pulse/native:/run/pulse/native:ro \
+      -e PULSE_SERVER=/run/pulse/native \
+      --name spotify \
+      spotify

--- a/spotify/run
+++ b/spotify/run
@@ -5,6 +5,7 @@ chmod 777 $HOME/.spotify/*
 xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $HOME/.spotify/xauth nmerge -
 exec docker run \
       --rm \
+      --shm-size 1G \
       -v /etc/localtime:/etc/localtime:ro \
       -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
       -e DISPLAY \

--- a/spotify/run
+++ b/spotify/run
@@ -2,15 +2,18 @@
 mkdir -p $HOME/.spotify/{config,cache,dbus}
 chmod 700 $HOME/.spotify
 chmod 777 $HOME/.spotify/*
+xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $HOME/.spotify/xauth nmerge -
 exec docker run \
       --rm \
       -v /etc/localtime:/etc/localtime:ro \
       -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
-      -e DISPLAY=unix$DISPLAY \
+      -e DISPLAY \
       -v $HOME/.spotify/config:/home/spotify/.config/spotify \
       -v $HOME/.spotify/cache:/home/spotify/.cache/spotify \
       -v $HOME/.spotify/dbus:/tmp/dbus \
+      -v $HOME/.spotify/xauth:/home/spotify/.Xauthority:ro \
       -v /run/user/$UID/pulse/native:/run/pulse/native:ro \
       -e PULSE_SERVER=/run/pulse/native \
+      -e QT_X11_NO_MITSHM=1 \
       --name spotify \
       spotify

--- a/spotify/session-local.conf
+++ b/spotify/session-local.conf
@@ -1,0 +1,5 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <listen>unix:path=/tmp/dbus/sock</listen>
+</busconfig>

--- a/spotify/session-local.conf
+++ b/spotify/session-local.conf
@@ -1,5 +1,0 @@
-<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
- "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
-<busconfig>
-  <listen>unix:path=/tmp/dbus/sock</listen>
-</busconfig>

--- a/spotify/spotify-dbus-wrap
+++ b/spotify/spotify-dbus-wrap
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Try something like:
+#   ./spotify-dbus-wrap dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.PlayPause
+# See http://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html for more.
+DBUS_SESSION_BUS_ADDRESS=unix:path=$HOME/.spotify/dbus/sock "$@"

--- a/spotify/startup
+++ b/spotify/startup
@@ -1,0 +1,5 @@
+#!/bin/sh
+addr='unix:path=/tmp/dbus/sock'
+DBUS_SESSION_BUS_ADDRESS=$(dbus-daemon --session --address=$addr --print-address --fork)
+export DBUS_SESSION_BUS_ADDRESS
+exec spotify -stylesheet=/home/spotify/spotify-override.css "$@"


### PR DESCRIPTION
Hi,

I just tried out your spotify container and had a couple tweaks to make it work better for me:
- switched to pulseaudio instead of direct alsa (I'm using ubuntu 14/15 as my host OS)
- provide access to the private dbus that gets created automatically inside the container, so I can control spotify from the host os (the alternative would be giving spotify access to the host session dbus, which seems like a security risk and sort of defeats the purpose of containerization)
- turn the "docker run" suggestion comment into a runnable wrapper script that should work for most people.

Let me know what you think.