### PR TITLE
Add Libcanberra-gtk-module

### DIFF
--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -12,6 +12,7 @@ RUN sed -i.bak 's/sid main/sid main contrib/g' /etc/apt/sources.list && \
 	libdbus-glib-1-2 \
 	libgl1-mesa-dri \
 	libgl1-mesa-glx \
+	libcanberra-gtk-module \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Adding libcanberra-gtk-module to fix a crash when running this Dockerfile on unbuntu 14.04
```
root@fb9f5404a971:/# firefox 

(firefox:5): Gtk-WARNING **: Locale not supported by C library.
 Using the fallback 'C' locale.
Gtk-Message: Failed to load module "canberra-gtk-module"
[5] ###!!! ABORT: X_ShmPutImage: BadValue (integer parameter out of range for operation); 9 requests ago: file /builds/slave/rel-m-rel-l64_bld-000000000000/build/toolkit/xre/nsX11ErrorHandler.cpp, line 157
[5] ###!!! ABORT: X_ShmPutImage: BadValue (integer parameter out of range for operation); 9 requests ago: file /builds/slave/rel-m-rel-l64_bld-000000000000/build/toolkit/xre/nsX11ErrorHandler.cpp, line 157
root@fb9f5404a971:/# 
(process:36): Gtk-WARNING **: Locale not supported by C library.
 Using the fallback 'C' locale.
Gtk-Message: Failed to load module "canberra-gtk-module"
```