### PR TITLE
Redoing mitmproxy for the Ubuntu image to workaround building pillow

### DIFF
--- a/mitmproxy/Dockerfile
+++ b/mitmproxy/Dockerfile
@@ -1,19 +1,31 @@
-FROM alpine:latest
+FROM ubuntu:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
+RUN apt-get update && apt-get install -y \
+        python \
+        python-dev \
+        python-virtualenv 
+
+RUN buildDeps=' \
+        libjpeg8-dev \
+        libffi-dev \
+        libssl-dev \
+        libxml2-dev \
+        libxslt1-dev \
+        zlib1g-dev \
+    ' \
+    && set -x \
+    && apt-get install -y ${buildDeps} --no-install-recommends \
+    && useradd -m mitm \
+    && su -c "virtualenv /home/mitm/mitmproxy" mitm \
+    && su -c "/home/mitm/mitmproxy/bin/pip install Pillow==3.0 mitmproxy" mitm \
+    && apt-get purge -y --auto-remove ${buildDeps} build-essential gcc \
+    && rm -rf /var/lib/apt/lists/* 
+
+EXPOSE 8080
+
+ENV HOME /home/mitm
 ENV LANG en_US.UTF-8
 
-RUN apk update && apk add \
-	build-base \
-	ca-certificates \
-	libffi-dev \
-	libxml2-dev \
-	libxslt-dev \
-	openssl-dev \
-	python \
-	python-dev \
-	py-pip \
-	&& rm -rf /var/cache/apk/* \
-	&& pip install pillow==2.8.0 mitmproxy
-
-CMD [ "mitmproxy" ]
+USER mitm
+CMD [ "/home/mitm/mitmproxy/bin/python", "/home/mitm/mitmproxy/bin/mitmproxy" ]

--- a/mitmproxy/Dockerfile
+++ b/mitmproxy/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
 RUN apt-get update && apt-get install -y \
+        libxslt1.1 \
+        libjpeg8 \
         python \
         python-dev \
         python-virtualenv 
@@ -19,7 +21,7 @@ RUN buildDeps=' \
     && useradd -m mitm \
     && su -c "virtualenv /home/mitm/mitmproxy" mitm \
     && su -c "/home/mitm/mitmproxy/bin/pip install Pillow==3.0 mitmproxy" mitm \
-    && apt-get purge -y --auto-remove ${buildDeps} build-essential gcc \
+    && apt-get purge -y --auto-remove ${buildDeps} \
     && rm -rf /var/lib/apt/lists/* 
 
 EXPOSE 8080


### PR DESCRIPTION
Greetings. I could not get mitmproxy working reasonably under Alpine so this pull request proposes a rebuild onto Ubuntu. Unfortunately the Ubuntu image is substantially larger (460MB as opposed to the 250MB for Alpine). 

Here is a description of the problem I encountered:

The alpine-based docker image builds properly, but mitmproxy will not run
due to the version of Pillow:

    $ docker build -t mitmproxy:nowork .
    Sending build context to Docker daemon 14.85 kB
    Sending build context to Docker daemon
    Step 0 : FROM alpine:latest
     ---> 340b2f9a2643
    Step 1 : MAINTAINER Jessica Frazelle <jess@docker.com>
     ---> Using cache
     ---> a3bd791c7821
    Step 2 : ENV LANG en_US.UTF-8
     ---> Using cache
     ---> cba5427643ae
    Step 3 : RUN apk update && apk add      build-base      ca-certificates         libffi-dev      libxml2-dev      libxslt-dev     openssl-dev     python  python-dev      py-pip  && rm -rf /var/cache/apk/*      && pip install pillow==2.8.0 mitmproxy
     ---> Using cache
     ---> 3464f49ada5d
    Step 4 : CMD mitmproxy
     ---> Using cache
     ---> 4f25006d730e
    Successfully built 4f25006d730e
    $ docker run --rm -ti mitmproxy:nowork
    Traceback (most recent call last):
      File "/usr/bin/mitmproxy", line 5, in <module>
        from pkg_resources import load_entry_point
      File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3138, in <module>
        @_call_aside
      File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3124, in _call_aside
        f(*args, **kwargs)
      File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3151, in _initialize_master_working_set
        working_set = WorkingSet._build_master()
      File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 663, in _build_master
        return cls._build_from_requirements(__requires__)
      File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 676, in _build_from_requirements
        dists = ws.resolve(reqs, Environment())
      File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 849, in resolve
        raise DistributionNotFound(req, requirers)
    pkg_resources.DistributionNotFound: The 'Pillow<3.1,>=3.0.0' distribution was not found and is required by mitmproxy

As you can see, mitmproxy now appears to rely on Pillow 3.0 - starting at Pillow 3.0, zlib is required per https://pillow.readthedocs.org/en/3.0.x/installation.html . Even though one can install zlib-dev, it is not recognized by the pillow build:

    / # apk info zlib
    zlib-1.2.8-r2 description:
    A compression/decompression Library

    zlib-1.2.8-r2 webpage:
    http://zlib.net

    zlib-1.2.8-r2 installed size:
    98304

    / # apk info -L zlib-dev
    zlib-dev-1.2.8-r2 contains:
    lib/libz.a
    lib/libz.so
    usr/lib/pkgconfig/zlib.pc
    usr/include/zlib.h
    usr/include/zconf.h
    / # pip install Pillow==3.0  2>/dev/null | tail
            self.distribution.run_command(command)
          File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
            cmd_obj.run()
          File "/usr/lib/python2.7/distutils/command/build_ext.py", line 339, in run
            self.build_extensions()
          File "/tmp/pip-build-CVBAPR/Pillow/setup.py", line 515, in build_extensions
            % (f, f))
        ValueError: --enable-zlib requested but zlib not found, aborting.

        ----------------------------------------

It is a mystery to me why this happens. But I figured the solution would be more complex than just choosing a different base image. If you choose to decline this PR maybe the problem can be solved with a patch to the Pillow team.

Thanks!