### PR TITLE
Add texlive (LaTeX compiler)

### DIFF
--- a/texlive/Dockerfile
+++ b/texlive/Dockerfile
@@ -1,0 +1,16 @@
+# TeX Live and biber
+#
+# Example usage:
+# docker run -it -w '/mnt' -v `pwd`:/mnt texlive /bin/bash -c './compile.sh'
+#
+# Example use case:
+# https://github.com/andygrunwald/FOM-LaTeX-Template
+
+FROM debian:jessie
+MAINTAINER Christian Koep <christian.koep@fom-net.de>
+
+RUN apt-get update && apt-get install -y \
+    texlive-full \
+    biber \
+    --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I'm using this docker image pretty frequently for compiling LaTeX documents in a container.

IDK if you want to add this to your repo but here it is.