### PR TITLE
Thanks for being so organized! \o/

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# This script allows you to launch several images
+# from this repository once they're built.
+#
+# Make sure you add the `docker run` command
+# in the header of the Dockerfile so the script
+# can find it and execute it.
+#
+# Use pulseaudio/Dockerfile and skype/Dockerfile as examples.
+
+if [ $# -eq 0 ]; then
+	echo "Usage: $0 [--test] image1 image2 ..."
+	exit 1
+fi
+
+if [ "$1" = "--test" ]; then
+	TEST=1
+	shift
+fi
+
+for name in "$@"; do
+	if [ ! -d $name ]; then
+		echo "unable to find container configuration with name $name"
+		exit 1
+	fi
+
+	script=`sed -n '/docker run/,/^#$/p' $name/Dockerfile | head -n -1 | sed -e 's/\#//' | sed -e 's/\\\//'`
+
+	if [ $TEST ]; then
+		echo $script
+	else
+		eval $script
+	fi
+
+	shift
+done

--- a/skype/Dockerfile
+++ b/skype/Dockerfile
@@ -7,6 +7,7 @@
 #	--link pulseaudio:pulseaudio \
 #	-e PULSE_SERVER=pulseaudio \
 #	--device /dev/video0 \
+#	--name skype
 #	jess/skype
 #
 FROM debian:jessie


### PR DESCRIPTION
I needed to use Skype this morning, but instead of actually using Skype I spent half an hour checking this repo and the Skype container.

Thanks for adding how to run the container in the header of the Dockerfile. Since I'm too lazy to copy and paste it, I thought that I could write a script to extract
the command from the header and run it for me. So here it is:

```
$ ./run.sh pulseaudio skype
```

This command will:

1. Find the `docker run` command in the header of pulseaudio/Dockerfile and skype/Dockerfile.
2. Run those commands in the order you set the arguments.

I noticed that some Dockerfiles don't have that header. I'll leave it as an exercise for the reader. :metal:

![](http://cdn.earthporm.com/wp-content/uploads/2014/07/cute-bunnies-tongues-6.jpg)