### PR TITLE
Use `apk --no-cache' on alpine images

### DIFF
--- a/ab/Dockerfile
+++ b/ab/Dockerfile
@@ -7,11 +7,10 @@
 FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
-RUN apk update && apk add \
+RUN apk --no-cache add \
 	apache2-ssl \
 	apache2-utils \
 	ca-certificates \
-	htop \
-	&& rm -rf /var/cache/apk/*
+	htop
 
 ENTRYPOINT [ "ab" ]

--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -18,8 +18,7 @@ RUN builddeps=' \
 		libffi-dev \
 		gcc \
 		' \
-	&& apk update \
-	&& apk add \
+	&& apk --no-cache add \
 	ca-certificates \
 	python \
 	py-paramiko \
@@ -27,7 +26,6 @@ RUN builddeps=' \
 	py-jinja2 \
 	py-httplib2 \
 	$builddeps \
-	&& rm -rf /var/cache/apk/* \
 	&& pip install --upgrade pip \
 	&& pip install \
 		ansible \

--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,13 +1,12 @@
 FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
-RUN apk update && apk add \
+RUN apk --no-cache add \
 	ca-certificates \
 	groff \
 	less \
 	python \
 	py-pip \
-	&& rm -rf /var/cache/apk/* \
 	&& pip install awscli \
 	&& mkdir -p /root/.aws \
 	&& { \

--- a/beeswithmachineguns/Dockerfile
+++ b/beeswithmachineguns/Dockerfile
@@ -1,13 +1,12 @@
 FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
-RUN apk update && apk add \
+RUN apk --no-cache add \
 	ca-certificates \
 	git \
 	python \
 	py-boto \
-	py-paramiko \
-	&& rm -rf /var/cache/apk/*
+	py-paramiko
 
 RUN git clone https://github.com/newsapps/beeswithmachineguns /usr/src/beeswithmachineguns \
 	&& cd /usr/src/beeswithmachineguns \

--- a/buttslock/Dockerfile
+++ b/buttslock/Dockerfile
@@ -9,15 +9,14 @@
 # And it also requires the USER and DISPLAY environment variables to be set.
 #
 FROM alpine
-RUN apk --update add \
+RUN apk --no-cache add \
 	i3lock \
 	imagemagick \
 	py-dbus \
 	py-gobject \
 	scrot \
 	ttf-liberation \
-	xkeyboard-config \
-	&& rm -rf /var/cache/apk/*
+	xkeyboard-config
 
 COPY buttslock.py buttslock.sh lock.png /
 

--- a/camlistore/Dockerfile
+++ b/camlistore/Dockerfile
@@ -4,9 +4,8 @@ MAINTAINER Jessica Frazelle <jess@docker.com>
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 
-RUN	apk update && apk add \
-	ca-certificates \
-	&& rm -rf /var/cache/apk/*
+RUN	apk --no-cache add \
+	ca-certificates
 
 RUN buildDeps=' \
 		go \
@@ -16,8 +15,7 @@ RUN buildDeps=' \
 		libgcc \
 	' \
 	set -x \
-	&& apk update \
-	&& apk add $buildDeps \
+	&& apk --no-cache add $buildDeps \
 	&& mkdir -p /go/src/camlistore.googlesource.com \
 	&& cd /go/src/camlistore.googlesource.com \
 	&& git clone --depth 1 -b 0.9 https://camlistore.googlesource.com/camlistore.git \
@@ -25,7 +23,6 @@ RUN buildDeps=' \
 	&& go run make.go \
 	&& cp -r ./bin/* /usr/local/bin/ \
 	&& apk del $buildDeps \
-	&& rm -rf /var/cache/apk/* \
 	&& rm -rf /go \
 	&& echo "Build complete."
 

--- a/cli53/Dockerfile
+++ b/cli53/Dockerfile
@@ -1,10 +1,9 @@
 FROM alpine:latest
 
-RUN apk update && apk add \
+RUN apk --no-cache add \
 	ca-certificates \
 	python \
 	py-pip \
-	&& rm -rf /var/cache/apk/* \
 	&& pip install cli53
 
 ENTRYPOINT [ "cli53" ]

--- a/consul/Dockerfile
+++ b/consul/Dockerfile
@@ -6,10 +6,9 @@ ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 #ENV GO15VENDOREXPERIMENT 1
 
-RUN	apk update && apk add \
+RUN	apk --no-cache add \
 	ca-certificates \
-	curl \
-	&& rm -rf /var/cache/apk/*
+	curl
 
 ENV CONSUL_VERSION v0.6.4
 
@@ -28,8 +27,7 @@ RUN buildDeps=' \
 		zip \
 	' \
 	set -x \
-	&& apk update \
-	&& apk add $buildDeps \
+	&& apk --no-cache add $buildDeps \
 	&& go get github.com/Soulou/curl-unix-socket \
 	&& mv /go/bin/curl-unix-socket /usr/bin/ \
 	&& mkdir -p /go/src/github.com/hashicorp /etc/consul.d \
@@ -46,7 +44,6 @@ RUN buildDeps=' \
 	&& mv static /usr/src/consul/ \
 	&& mv javascripts /usr/src/consul/ \
 	&& apk del $buildDeps \
-	&& rm -rf /var/cache/apk/* \
 	&& rm -rf /go \
 	&& echo "Build complete."
 

--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -6,8 +6,7 @@
 FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
-RUN apk update && apk add \
-	curl \
-	&& rm -rf /var/cache/apk/*
+RUN apk --no-cache add \
+	curl
 
 CMD [ "curl" ]

--- a/dcos-cli/Dockerfile
+++ b/dcos-cli/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
-RUN apk update && apk add \
+RUN apk --no-cache add \
 	ca-certificates \
 	python \
 	py-pip \
-	&& rm -rf /var/cache/apk/* \
 	&& pip install dcoscli
 
 # path to the DCOS CLI binary

--- a/doctor/Dockerfile
+++ b/doctor/Dockerfile
@@ -3,7 +3,7 @@
 # AUTHOR:		  Jessica Frazelle <jess@docker.com>
 # COMMENTS:
 #	This file describes how to build doctor in a container with all
-#	dependencies installed. 
+#	dependencies installed.
 #	Tested on Debian Jessie
 # USAGE:
 #	# Download doctor Dockerfile
@@ -20,11 +20,10 @@ FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
 # Install emacs:
-# Note: Eamcs is only in testing repo -> http://pkgs.alpinelinux.org/packages?package=emacs&repo=all&arch=x86_64
-RUN apk update && apk add \
-	emacs \
-	--update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
-	&& rm -rf /var/cache/apk/*
+# Note: Emacs is only in testing repo -> http://pkgs.alpinelinux.org/packages?package=emacs&repo=all&arch=x86_64
+RUN apk --no-cache add \
+	--repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+	emacs
 
 # Autorun doctor
 CMD ["/usr/bin/emacs", "-f", "doctor"]

--- a/dunnet/Dockerfile
+++ b/dunnet/Dockerfile
@@ -20,11 +20,10 @@ FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
 # Install emacs:
-# Note: Eamcs is only in testing repo -> http://pkgs.alpinelinux.org/packages?package=emacs&repo=all&arch=x86_64
-RUN apk update && apk add \
-	emacs \
-	--update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
-	&& rm -rf /var/cache/apk/*
+# Note: Emacs is only in testing repo -> http://pkgs.alpinelinux.org/packages?package=emacs&repo=all&arch=x86_64
+RUN apk --no-cache add \
+	--repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+	emacs
 
 # Autorun dunnet
 CMD ["/usr/bin/emacs", "-batch", "-l", "dunnet"]

--- a/gcalcli/Dockerfile
+++ b/gcalcli/Dockerfile
@@ -3,12 +3,11 @@ MAINTAINER Jessica Frazelle <jess@docker.com>
 
 ENV HOME /home/gcalcli
 
-RUN apk update && apk add \
+RUN apk --no-cache add \
 	python \
 	python-dev \
 	py-pip \
 	build-base \
-	&& rm -rf /var/cache/apk/* \
 	&& adduser -S gcalcli \
 	&& chown -R gcalcli $HOME \
 	&& pip install vobject parsedatetime gcalcli

--- a/gitiles/Dockerfile
+++ b/gitiles/Dockerfile
@@ -11,8 +11,8 @@ RUN buildDeps=' \
 		zip \
 	' \
 	set -x \
-	&& apk --update add $buildDeps \
-	--update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \
+	&& apk --no-cache add $buildDeps \
+	--repository http://dl-3.alpinelinux.org/alpine/edge/community/ \
 	&& git clone --depth 1 https://github.com/facebook/buck.git /buck \
 	&& ( \
 		cd /buck \
@@ -27,8 +27,7 @@ RUN buildDeps=' \
 		&& buck build gitiles-dev:dev \
 	) \
 	&& apk del $buildDeps \
-	&& rm -rf /buck \
-	&& rm -rf /var/cache/apk/*
+	&& rm -rf /buck
 
 COPY start.sh /start.sh
 

--- a/gitserver/Dockerfile
+++ b/gitserver/Dockerfile
@@ -10,10 +10,9 @@ MAINTAINER Jessica Frazelle <jess@docker.com>
 
 ENV HOME /root
 
-RUN apk update && apk add \
+RUN apk --no-cache add \
 	git \
 	openssh \
-	&& rm -rf /var/cache/apk/* \
 	&& sed -i "s/#PasswordAuthentication yes/PasswordAuthentication no/" /etc/ssh/sshd_config \
 	&& sed -i "s/#PubkeyAuthentication yes/PubkeyAuthentication yes/" /etc/ssh/sshd_config \
 	&& echo -e "AllowUsers git\n" >> /etc/ssh/sshd_config \

--- a/httpie/Dockerfile
+++ b/httpie/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
-RUN apk update && apk add \
+RUN apk --no-cache add \
 	ca-certificates \
 	python \
 	py-pip \
-	&& rm -rf /var/cache/apk/* \
 	&& pip install httpie httpie-unixsocket
 
 ENTRYPOINT [ "http" ]

--- a/imagemagick/Dockerfile
+++ b/imagemagick/Dockerfile
@@ -1,8 +1,7 @@
 FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
-RUN apk update && apk add \
-	imagemagick \
-	&& rm -rf /var/cache/apk/*
+RUN apk --no-cache add \
+	imagemagick
 
 CMD [ "echo", "Use one of the following commands [ animate | compare | composite | conjure | convert | display | identify | import | mogrify | montage | stream ]" ]

--- a/imagemin/Dockerfile
+++ b/imagemin/Dockerfile
@@ -9,7 +9,7 @@
 FROM alpine
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
-RUN apk update && apk add \
+RUN apk --no-cache add \
 	autoconf \
 	automake \
 	build-base \
@@ -17,7 +17,6 @@ RUN apk update && apk add \
 	libpng-dev \
 	nasm \
 	nodejs \
-	&& rm -rf /var/cache/apk/* \
 	&& npm install --global imagemin-cli
 
 CMD [ "imagemin", "--help" ]

--- a/libvirt-client/Dockerfile
+++ b/libvirt-client/Dockerfile
@@ -1,8 +1,7 @@
 FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
-RUN apk update && apk add \
-	libvirt-client \
-	&& rm -rf /var/cache/apk/*
+RUN apk --no-cache add \
+	libvirt-client
 
 ENTRYPOINT [ "virsh", "-c", "qemu:///system" ]

--- a/mutt/Dockerfile
+++ b/mutt/Dockerfile
@@ -14,7 +14,7 @@ MAINTAINER Jessica Frazelle <jess@docker.com>
 RUN addgroup -g 1000 user \
 	&& adduser -D -h /home/user -G user -u 1000 user
 
-RUN apk --update add \
+RUN apk --no-cache add \
 	ca-certificates \
 	elinks \
 	git \
@@ -22,8 +22,7 @@ RUN apk --update add \
 	lynx \
 	mutt \
 	mutt-doc \
-	vim \
-	&& rm -rf /var/cache/apk/*
+	vim
 
 # a browser is necessary!
 ENV BROWSER lynx

--- a/openvpn/Dockerfile
+++ b/openvpn/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine:latest
-RUN apk update && apk add \
-	openvpn \
-	&& rm -rf /var/cache/apk/*
+RUN apk --no-cache add \
+	openvpn
 
 WORKDIR /etc/openvpn
 ENTRYPOINT ["openvpn"]

--- a/privoxy/Dockerfile
+++ b/privoxy/Dockerfile
@@ -11,9 +11,8 @@
 FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
-RUN apk update && apk add \
-	privoxy \
-	&& rm -rf /var/cache/apk/*
+RUN apk --no-cache add \
+	privoxy
 
 # expose http port
 EXPOSE 8118

--- a/rainbowstream/Dockerfile
+++ b/rainbowstream/Dockerfile
@@ -10,7 +10,7 @@
 FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
-RUN apk update && apk add \
+RUN apk --no-cache add \
 	build-base \
 	ca-certificates \
 	freetype \
@@ -20,7 +20,6 @@ RUN apk update && apk add \
 	python-dev \
 	py-pip \
 	zlib-dev \
-	&& rm -rf /var/cache/apk/* \
 	&& pip install pillow==2.8.0 rainbowstream
 
 ENTRYPOINT [ "rainbowstream" ]

--- a/shorewall/Dockerfile
+++ b/shorewall/Dockerfile
@@ -9,9 +9,8 @@
 FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
-RUN apk update && apk add \
+RUN apk --no-cache add \
 	shorewall \
-	&& rm -rf /var/cache/apk/* \
 	&& touch /var/log/messages
 
 COPY ./etc /etc/shorewall

--- a/t/Dockerfile
+++ b/t/Dockerfile
@@ -1,12 +1,11 @@
 FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
-RUN apk update && apk add \
+RUN apk --no-cache add \
 	build-base \
 	ca-certificates \
 	ruby \
 	ruby-dev \
-	&& rm -rf /var/cache/apk/* \
 	&& gem install --no-document io-console t
 
 ENTRYPOINT [ "t" ]

--- a/tetris/Dockerfile
+++ b/tetris/Dockerfile
@@ -3,7 +3,7 @@
 # AUTHOR:		  Jessica Frazelle <jess@docker.com>
 # COMMENTS:
 #	This file describes how to build tetris in a container with all
-#	dependencies installed. 
+#	dependencies installed.
 #	Tested on Debian Jessie
 # USAGE:
 #	# Download tetris Dockerfile
@@ -20,11 +20,10 @@ FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
 # Install emacs:
-# Note: Eamcs is only in testing repo -> http://pkgs.alpinelinux.org/packages?package=emacs&repo=all&arch=x86_64
-RUN apk update && apk add \
-	emacs \
-	--update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
-	&& rm -rf /var/cache/apk/*
+# Note: Emacs is only in testing repo -> http://pkgs.alpinelinux.org/packages?package=emacs&repo=all&arch=x86_64
+RUN apk --no-cache add \
+	--repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+	emacs
 
 # Autorun tetris
 CMD ["/usr/bin/emacs", "-f", "tetris"]

--- a/tor-proxy/Dockerfile
+++ b/tor-proxy/Dockerfile
@@ -11,10 +11,9 @@ FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
 # Note: Tor is only in testing repo -> http://pkgs.alpinelinux.org/packages?package=emacs&repo=all&arch=x86_64
-RUN apk update && apk add \
-	tor \
-	--update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
-	&& rm -rf /var/cache/apk/*
+RUN apk --no-cache add \
+	--repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+	tor
 
 # expose socks port
 EXPOSE 9050

--- a/tor-relay/Dockerfile
+++ b/tor-relay/Dockerfile
@@ -20,10 +20,9 @@ FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
 # Note: Tor is only in testing repo -> http://pkgs.alpinelinux.org/packages?package=emacs&repo=all&arch=x86_64
-RUN apk update && apk add \
-	tor \
-	--update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
-	&& rm -rf /var/cache/apk/*
+RUN apk --no-cache add \
+	--repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+	tor
 
 # default port to used for incoming Tor connections
 # can be changed by changing 'ORPort' in torrc

--- a/transmission/Dockerfile
+++ b/transmission/Dockerfile
@@ -22,9 +22,8 @@
 FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
-RUN apk update && apk add \
+RUN apk --no-cache add \
 	transmission-daemon \
-	&& rm -rf /var/cache/apk/* \
 	&& mkdir -p /transmission/{download,watch,incomplete,config} \
 	&& chmod 1777 /transmission
 

--- a/vault/Dockerfile
+++ b/vault/Dockerfile
@@ -5,10 +5,9 @@ MAINTAINER Jessica Frazelle <jess@mesosphere.com>
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 
-RUN	apk update && apk add \
+RUN	apk --no-cache add \
 	ca-certificates \
-	curl \
-	&& rm -rf /var/cache/apk/*
+	curl
 
 ENV VAULT_VERSION v0.5.3
 
@@ -24,8 +23,7 @@ RUN buildDeps=' \
 		zip \
 	' \
 	set -x \
-	&& apk update \
-	&& apk add $buildDeps \
+	&& apk --no-cache add $buildDeps \
 	&& mkdir -p /go/src/github.com/hashicorp \
 	&& git clone --branch ${VAULT_VERSION} https://github.com/hashicorp/vault /go/src/github.com/hashicorp/vault \
 	&& cd /go/src/github.com/hashicorp/vault \
@@ -33,7 +31,6 @@ RUN buildDeps=' \
 	&& XC_ARCH="amd64" XC_OS="linux" XC_OSARCH="linux/amd64" make bin \
 	&& mv bin/vault /usr/bin/ \
 	&& apk del $buildDeps \
-	&& rm -rf /var/cache/apk/* \
 	&& rm -rf /go \
 	&& echo "Build complete."
 

--- a/wargames/Dockerfile
+++ b/wargames/Dockerfile
@@ -1,9 +1,8 @@
 FROM alpine:latest
 MAINTAINER Jessica Frazelle <jess@docker.com>
 
-RUN apk update && apk add \
-	ncurses \
-	&& rm -rf /var/cache/apk/*
+RUN apk --no-cache add \
+	ncurses
 
 RUN set -x \
 	&& apk add --no-cache --virtual .build-deps \

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -4,21 +4,19 @@ ENV ZOOKEEPER_VERSION 3.4.8
 ENV PATH $PATH:/opt/zookeeper/bin/
 
 # the start files for zookeeper use bash
-RUN apk --update add \
-	bash \
-	&& rm -rf /var/cache/apk/*
+RUN apk --no-cache add \
+	bash
 
 RUN buildDeps=' \
 		curl \
 	' \
 	&& echo "==> Installing dependencies..." \
-	&& apk --update add --virtual build-deps $buildDeps \
+	&& apk --no-cache add --virtual build-deps $buildDeps \
 	&& echo "==> Downloading Zookeeper..." \
 	&& mkdir -p /opt \
 	&& curl -sSL http://apache.mirrors.pair.com/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/zookeeper-${ZOOKEEPER_VERSION}.tar.gz | tar -xzf - -C /opt \
 	&& mv /opt/zookeeper-${ZOOKEEPER_VERSION} /opt/zookeeper \
-    && cp /opt/zookeeper/conf/zoo_sample.cfg /opt/zookeeper/conf/zoo.cfg \
-	&& apk del build-deps \
-	&& rm -rf /var/cache/apk/*
+	&& cp /opt/zookeeper/conf/zoo_sample.cfg /opt/zookeeper/conf/zoo.cfg \
+	&& apk del build-deps
 
 ENTRYPOINT ["zkServer.sh", "start-foreground"]


### PR DESCRIPTION
As suggested on https://github.com/jfrazelle/blog/pull/15#issuecomment-223811952, I bring you this super PR. I think `apt-get` could be similarly improved, but I haven't found any official doc for doing something like apk does.

----
This enables us to remove the following patterns that required a `rm -rf /var/cache/apk`:

- `apk update`
- `apk add --update`
- `apk add --update-cache`

Supported since alpine 3.3.