### PR TITLE
Fix metasploit

### DIFF
--- a/metasploit/Dockerfile
+++ b/metasploit/Dockerfile
@@ -1,7 +1,7 @@
 FROM kalilinux/kali-linux-docker
 MAINTAINER Christian Koep <christian.koep@fom-net.de>
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     metasploit-framework \
     --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Hi,

so I was getting this error with the metasploit image

```bash
rake aborted!
LoadError: /usr/lib/x86_64-linux-gnu/ruby/2.3.0/openssl.so: symbol SSLv2_method, version OPENSSL_1.0.2d not defined in file libssl.so.1.0.2 with link time reference - /usr/lib/x86_64-linux-gnu/ruby/2.3.0/openssl.so
/usr/share/metasploit-framework/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.6/lib/active_support/key_generator.rb:2:in `require'
/usr/share/metasploit-framework/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.6/lib/active_support/key_generator.rb:2:in `<top (required)>'
/usr/share/metasploit-framework/vendor/bundle/ruby/2.3.0/gems/railties-4.2.6/lib/rails/application.rb:5:in `require'
/usr/share/metasploit-framework/vendor/bundle/ruby/2.3.0/gems/railties-4.2.6/lib/rails/application.rb:5:in `<top (required)>'
/usr/share/metasploit-framework/vendor/bundle/ruby/2.3.0/gems/railties-4.2.6/lib/rails.rb:11:in `require'
/usr/share/metasploit-framework/vendor/bundle/ruby/2.3.0/gems/railties-4.2.6/lib/rails.rb:11:in `<top (required)>'
/usr/share/metasploit-framework/config/application.rb:1:in `require'
/usr/share/metasploit-framework/config/application.rb:1:in `<top (required)>'
/usr/share/metasploit-framework/Rakefile:2:in `require'
/usr/share/metasploit-framework/Rakefile:2:in `<top (required)>'
(See full trace by running task with --trace)
```

I fixed it by "apt-get upgrading" the whole thing. There might be a more elegant way to fix it, but I guess I'm not that much of a tinkerer ;-)