### PR TITLE
changed keys.gnupg.net to pool.sks-keyservers.net 

### DIFF
--- a/tor-browser/stable/Dockerfile
+++ b/tor-browser/stable/Dockerfile
@@ -34,7 +34,7 @@ RUN cd /tmp \
 	&& curl -sSOL "https://www.torproject.org/dist/torbrowser/${TOR_VERSION}/tor-browser-linux64-${TOR_VERSION}_en-US.tar.xz" \
 	&& curl -sSOL "https://www.torproject.org/dist/torbrowser/${TOR_VERSION}/tor-browser-linux64-${TOR_VERSION}_en-US.tar.xz.asc" \
 	&& mkdir ~/.gnupg \
-	&& gpg --keyserver x-hkp://keys.gnupg.net --recv-keys ${TOR_FINGERPRINT} \
+	&& gpg --keyserver "hkp://pool.sks-keyservers.net" --recv-keys ${TOR_FINGERPRINT} \
 	&& gpg --fingerprint ${TOR_FINGERPRINT} | grep "Key fingerprint = EF6E 286D DA85 EA2A 4BA7  DE68 4E2C 6E87 9329 8290" \
 	&& gpg --verify tor-browser-linux64-${TOR_VERSION}_en-US.tar.xz.asc \
 	&& tar -vxJ --strip-components 1 -C /usr/local/bin -f tor-browser-linux64-${TOR_VERSION}_en-US.tar.xz \


### PR DESCRIPTION

Hi,

old address failed docker build on mac - updated to dns resolved name for keys.gnupg.net

seems to work now on the mac - not sure if this croaks other platforms - doubt it.


<img width="897" alt="screen shot 2016-06-23 at 12 13 46" src="https://cloud.githubusercontent.com/assets/16922554/16301244/46618d4a-393c-11e6-88af-bab17e9ebc29.png">

<img width="762" alt="screen shot 2016-06-23 at 12 14 24" src="https://cloud.githubusercontent.com/assets/16922554/16301250/54627472-393c-11e6-9202-86b137fb3726.png">



