### PR TITLE
Skip deleted Dockerfiles from test suite

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -28,6 +28,10 @@ unset IFS
 
 # build the changed dockerfiles
 for f in "${files[@]}"; do
+	if ! [[ -e "$f" ]]; then
+		continue
+	fi
+
 	image=${f%Dockerfile}
 	base=${image%%\/*}
 	suite=${image##*\/}


### PR DESCRIPTION
The [Travis build failed](https://travis-ci.org/jfrazelle/dockerfiles/builds/140218033) because commit 2775f5c renamed the `visualstudio` Dockerfile to `vscode`. The `test.sh` script uses `git diff` to know which Dockerfiles changed, being the command for this particular build:

```sh
$ git diff 18b8688..2775f5c --name-only -- '*Dockerfile'
visualstudio/Dockerfile
vscode/Dockerfile
```

If we use `--name-status` we see:
```sh
$ git diff 18b8688..2775f5c --name-status -- '*Dockerfile'
D    visualstudio/Dockerfile      <-- 'D' means Deleted
A    vscode/Dockerfile
```

My suggested patch checks if the Dockerfile exists before attempting to build it.

-----
This fixes the build process which is currently failing due to the rename of `visualstudio/Dockerfile` to `vscode/Dockerfile`.

See https://travis-ci.org/jfrazelle/dockerfiles/builds/140218033