### PR TITLE
Sublime Text 3: No longer writes as root everywhere, other improvements

### DIFF
--- a/sublime-text-3/Dockerfile
+++ b/sublime-text-3/Dockerfile
@@ -1,16 +1,22 @@
-# VERSION:		0.1
+# VERSION:		0.2
 # DESCRIPTION:	Create sublime-text 3 container with its dependencies (https://www.sublimetext.com/3)
-# AUTHOR:		Christian Koep <christian.koep@fom-net.de>
+# AUTHORS:		Christian Koep <christian.koep@fom-net.de>, Chuck Knox <charles.m.knox@gmail.com>
 # USAGE:
 #	# Build sublime-text 3 image
 #	docker build -t sublime-text:3 .
 #
 #	# Run the container and mount the local settings and your code
-#	docker run -it \
-#		-v $HOME/.config/sublime-text-3/:/root/.config/sublime-text-3 \
-#		-v $HOME/development:/root/development \
-#		-v /tmp/.X11-unix:/tmp/.X11-unix \
-#		-e DISPLAY=$DISPLAY sublime-text:3
+#   # Your code must be under $HOME/Documents, you only need to change it here.
+#		docker run -d -it \
+#			-w $HOME/Documents \
+#			-v $HOME/.config/sublime-text-3:$HOME/.config/sublime-text-3 \
+#			-v $HOME/Documents:$HOME/Documents \
+#			-v /tmp/.X11-unix:/tmp/.X11-unix \
+#			-v $HOME/.local/share/recently-used.xbel:$HOME/.local/share/recently-used.xbel \
+#			-e DISPLAY=$DISPLAY \
+#			-e NEWUSER=$USER \
+#			-e LANG=en_US.UTF-8 \
+#			sublime-text:3
 #
 # POSSIBLE ISSUES:
 #	# 'Gtk: cannot open display: :0'
@@ -21,7 +27,10 @@
 FROM debian:jessie
 MAINTAINER Christian Koep <christian.koep@fom-net.de>
 
+# Installing the libcanberra-gtk-module gets rid of a lot of annoying error messages.
 RUN apt-get update && apt-get -y install \
+	locales \
+	libcanberra-gtk-module \
 	ca-certificates \
 	curl \
 	tar \
@@ -40,4 +49,21 @@ RUN curl -sSL "https://download.sublimetext.com/sublime_text_3_build_3114_x64.ta
 	&& tar -xjf /tmp/sublime.tar.bz2 -C /usr/src/sublime_text --strip-components 1 \
 	&& rm /tmp/sublime.tar.bz2*
 
-CMD ["/usr/src/sublime_text/sublime_text", "-w"]
+# Generate system-wide UTF-8 locale
+# Sublime might nag about Ascii issue w/ Package Control otherwise
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+	locale-gen && \
+	echo "LANG=en_US.UTF-8" > /etc/locale.conf
+
+# In order to prevent writing as root:root in Sublime, we have to run the Sublime Text container
+# as the user that creates the container. Normally we do this by passing $UID.
+# But just passing $UID along isn't enough - Sublime has to be started by a user that exists.
+# By default in the container, the only user that actually exists is root.
+# Therefore we have to create a new user, and start Sublime as that user.
+# This is not possible at build time, so the /run.sh script accepts an environment
+# variable called $NEWUSER that creates a user and group named $USER.
+# Additional note: Sublime puts a lot of stuff in ~/.config, which is mounted at runtime. Without this directory being mounted, settings/packages/etc won't persist.
+COPY run.sh /run.sh
+RUN chmod +x /run.sh
+
+CMD ["/run.sh"]

--- a/sublime-text-3/run.sh
+++ b/sublime-text-3/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+if [ -z ${NEWUSER+x} ]; then
+	echo 'WARN: No user was defined, defaulting to root.'
+	echo 'WARN: Sublime will save files as root:root.'
+	echo '      To prevent this, start the container with -e NEWUSER=$USER'
+	/usr/src/sublime_text/sublime_text -w
+else
+	# The root user already exists, so we only need to do something if
+	# a user has been specified.
+	useradd -s /bin/bash $NEWUSER
+	# If you'd like to have Sublime Text add your development folder
+	# to the current project (i.e. in the sidebar at start), append
+	# "-a /home/$NEWUSER/Documents" (without quotes) into the su -c command below.
+	# Example: su $NEWUSER -c "/usr/src/sublime_text/sublime_text -w -a /home/$NEWUSER/Documents"
+	su $NEWUSER -c "/usr/src/sublime_text/sublime_text -w"
+fi


### PR DESCRIPTION
When running the current sublime text image, everything writes as `root:root`. This pull request makes `$USER:$USER` the owner & group of every file that Sublime writes to.

In order to do this, it does the following:
* Adds a `/run.sh` script to the `CMD` part of the Dockerfile
* At runtime, the user and group `$USER` are created, and then Sublime is started as that user via `su -c`. *(The `$USER` is passed along as an env variable at container runtime)*

Note that this is *not* accomplished by using the `docker run -u $UID` flag. The user has to exist in the container, and that's what `/run.sh` does.

Additionally, this pull request remedies some other problems that I noticed while working on this:

* Installing `libcanberra-gtk-module` resolves a lot of error messages.
* Installing `locales` allows us to define a UTF-8 locale. For now, it's hardcoded to `en_US.UTF-8`. This is needed because Sublime will only work with ascii otherwise.

@koep , I see that you are the author of this Dockerfile. I wanted to tag you in this pull request to ensure that you get to see the change if it goes through.
