### PR TITLE
Install libpulse0

### DIFF
--- a/chrome/beta/Dockerfile
+++ b/chrome/beta/Dockerfile
@@ -28,6 +28,7 @@ RUN echo 'deb http://httpredir.debian.org/debian testing main' >> /etc/apt/sourc
 	hicolor-icon-theme \
 	libgl1-mesa-dri \
 	libgl1-mesa-glx \
+        libpulse0 \
 	libv4l-0 \
 	-t testing \
 	fonts-symbola \

--- a/chrome/stable/Dockerfile
+++ b/chrome/stable/Dockerfile
@@ -28,6 +28,7 @@ RUN echo 'deb http://httpredir.debian.org/debian testing main' >> /etc/apt/sourc
 	hicolor-icon-theme \
 	libgl1-mesa-dri \
 	libgl1-mesa-glx \
+        libpulse0 \
 	libv4l-0 \
 	-t testing \
 	fonts-symbola \


### PR DESCRIPTION
Required to use PulseAudio when binding natively from host.

I'm running Chrome container by binding PulseAudio from the host. But turns out I don't get any sound, because Chrome can't find libpulse.

So just install libpulse0 to fix it.
