### PR TITLE
Add skype user to irc group

### DIFF
--- a/skype/Dockerfile
+++ b/skype/Dockerfile
@@ -33,7 +33,7 @@ RUN curl http://download.skype.com/linux/skype-debian_4.3.0.37-1_i386.deb > /usr
 ENV HOME /home/skype
 RUN useradd --create-home --home-dir $HOME skype \
 	&& chown -R skype:skype $HOME \
-	&& usermod -a -G audio,video skype
+	&& usermod -a -G audio,video,irc skype
 
 WORKDIR $HOME
 USER skype


### PR DESCRIPTION
When running Skype container from Fedora, the gid for "video" group is
not the same as in Debian; in fact, it correspond to the gid for "irc"
group in Debian.

So in the container, /dev/video0 belongs to "irc" group, and thus skype
can't use it.

So a quick fix is to add skype to irc group, so it can use it without
any problem.