### PR TITLE
fix spotify dependencies

### DIFF
--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -19,11 +19,13 @@ RUN	apt-get update && apt-get install -y \
 	--no-install-recommends \
 	&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BBEBDCB318AD50EC6865090613B00F1FD2C19886 \
 	&& echo "deb http://repository.spotify.com stable non-free" >> /etc/apt/sources.list.d/spotify.list \
+	&& echo "deb http://ftp.de.debian.org/debian jessie main " >> /etc/apt/sources.list.d/workaround.list \
 	&& apt-get update && apt-get install -y \
 	alsa-utils \
 	libgl1-mesa-dri \
 	libgl1-mesa-glx \
 	libpangoxft-1.0-0 \
+	libssl1.0.0 \
 	libssl1.0.2 \
 	libxss1 \
 	spotify-client \


### PR DESCRIPTION
Fixes #176 for now. I think there is some fuckery going on with the dependencies of the spotify-client package.

https://community.spotify.com/t5/Desktop-Linux-Windows-Web-Player/spotify-linux-dependencies/td-p/1332735

@jfrazelle can you test this on your host and check if everything still works? 