### PR TITLE
Add mop-tracker.

### DIFF
--- a/mop/Dockerfile
+++ b/mop/Dockerfile
@@ -1,0 +1,12 @@
+# Run mop-tracker in a container
+#
+# docker run -it --rm \
+#       -v ~/.moprc:/root/.moprc \
+#       --name mop
+#       freebirdljj/mop
+FROM golang:latest
+MAINTAINER FreeBirdLjj
+
+RUN go get github.com/mop-tracker/mop && go install -x github.com/mop-tracker/mop/cmd/mop && rm -fr $GOPATH/src/github.com
+
+ENTRYPOINT ["mop"]


### PR DESCRIPTION
[mop](https://github.com/mop-tracker/mop): track stocks the hacker way.

Dockerize `mop` the stock tracker and this dockerfile has been tested on [dockerhub](https://hub.docker.com/r/freebirdljj/mop/) for months.